### PR TITLE
Improve version checking output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog v1.5.0
+- Added changelog display support
+- Fixed minor bugs
+
+# Changelog v1.4.0
+- Initial release


### PR DESCRIPTION
## Summary
- shorten version info header
- show changelog of latest version only when outdated

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858b32150cc8324a879e94985e9da3d